### PR TITLE
Add GitHub actions

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,0 +1,149 @@
+on:
+  push:
+  pull_request:
+    branches:
+      - devel
+  schedule:
+    - cron: '0 8 * * 5'
+
+name: R-CMD-check
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.bioc }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - { os: windows-latest, bioc: 'devel', deploy: 'no'}
+          - { os: macOS-12, bioc: 'devel', deploy: 'yes'}
+          # - { os: ubuntu-latest, r: 'devel', image: 'bioconductor/bioconductor_docker:devel', deploy: 'no'}
+
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      CRAN: ${{ matrix.config.cran }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      cache-version: v2
+
+    steps:
+      - name: checkout branch
+        uses: actions/checkout@v3
+
+      - name: Set up R and install BiocManager
+        uses: grimbough/bioc-actions/setup-bioc@v1
+        if: matrix.config.image == null
+        with:
+          bioc-version: ${{ matrix.config.bioc }}
+
+      - name: Set up pandoc
+        uses: r-lib/actions/setup-pandoc@v2
+        if: matrix.config.image == null
+
+      - name: Install remotes
+        run: |
+          install.packages(c('remotes'))
+        shell: Rscript {0}
+
+      - name: Query dependencies
+        run: |
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE, repos = c(getOption('repos'), BiocManager::repositories())), 'depends.Rds', version = 2)
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        if: runner.os != 'Windows' && matrix.config.image == null
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ env.cache-version }}-${{ runner.os }}-bioc-${{ matrix.config.bioc }}-${{ hashFiles('depends.Rds') }}
+          restore-keys: ${{ env.cache-version }}-${{ runner.os }}-bioc-${{ matrix.config.bioc }}-
+
+      # - name: Install Linux system dependencies
+      #   if: runner.os == 'Linux'
+      #   env:
+      #     RHUB_PLATFORM: linux-x86_64-ubuntu-gcc
+      #   run: |
+      #     sudo apt-get update && sudo apt-get -y install libharfbuzz-dev libfribidi-dev
+      #     Rscript -e "remotes::install_github('r-hub/sysreqs')"
+      #     sysreqs=$(Rscript -e "cat(sysreqs::sysreq_commands('DESCRIPTION'))")
+      #     sudo -s eval "$sysreqs"
+      # 
+      # - name: Install macOS system dependencies
+      #   if: runner.os == 'macOS'
+      #   run: |
+      #     brew install harfbuzz
+      #     brew install fribidi
+      #     Rscript -e 'BiocManager::install(c("GenomeInfoDbData"), type = "source")'
+      #     Rscript -e 'BiocManager::install(c("GenomicFeatures"), type = "source")'
+
+
+      - name: Install R package dependencies
+        run: |
+          local_deps <- remotes::local_package_deps(dependencies = TRUE)
+          deps <- remotes::dev_package_deps(dependencies = TRUE, repos = BiocManager::repositories())
+          print(deps)
+          BiocManager::install(local_deps[local_deps %in% deps$package[deps$diff != 0]], Ncpu = 2L)
+          remotes::install_cran('rcmdcheck', Ncpu = 2L)
+        shell: Rscript {0}
+
+      - name: Session info
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+        shell: Rscript {0}
+
+      - name: Build, Install, Check
+        id: build-install-check
+        uses: grimbough/bioc-actions/build-install-check@v1
+
+      - name: Upload install log if the build/install/check step fails
+        if: always() && (steps.build-install-check.outcome == 'failure')
+        uses: actions/upload-artifact@v3
+        with:
+          name: install-log
+          path: |
+            ${{ steps.build-install-check.outputs.install-log }}
+
+      - name: Show testthat output (windows)
+        if: always() && runner.os == 'Windows'
+        run: |
+            type ${{ steps.build-install-check.outputs.check-dir }}\tests\testthat.Rout
+        shell: cmd
+
+      - name: Show testthat output (non-windows)
+        if: always() && runner.os != 'Windows'
+        run: |
+            cat ${{ steps.build-install-check.outputs.check-dir }}/tests/testthat.Rout
+        shell: bash
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-results
+          path: ${{ steps.build-install-check.outputs.check-dir }}
+
+      - name: Run BiocCheck
+        uses: grimbough/bioc-actions/run-BiocCheck@v1
+        with:
+          arguments: '--no-check-bioc-views --no-check-bioc-help'
+          error-on: 'error'
+
+      - name: Test coverage
+        if: matrix.config.os == 'macOS-12' && matrix.config.bioc == 'devel'
+        run: |
+          install.packages("covr")
+          covr::codecov(token = "${{secrets.CODECOV_TOKEN}}")
+        shell: Rscript {0}
+
+      - name: Deploy
+        if: github.event_name == 'push' && github.ref == 'refs/heads/devel' && matrix.config.deploy == 'yes'
+        run: |
+          R CMD INSTALL .
+          Rscript -e "remotes::install_dev('pkgdown'); pkgdown::deploy_to_branch(new_process = FALSE)"
+
+

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,8 @@ Imports:
     tibble (>= 3.2.1),
     stats,
     IRanges,
-    rlang
+    rlang,
+    here
 URL:
 BugReports:
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,8 @@ Suggests:
     knitr,
     devtools,
     qpdf,
-    BiocStyle
+    BiocStyle,
+    ggplot2
 DEPENDS:
         dplyr (>= 1.1.2),
         GenomicRanges

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Suggests:
     rtracklayer,
     knitr,
     devtools,
-    qpdf
+    qpdf,
+    BiocStyle
 DEPENDS:
         dplyr (>= 1.1.2),
         GenomicRanges


### PR DESCRIPTION
I have added a typical GitHub actions workflow that installs the the package and its dependencies, and runs test like `R CMD check` and `BiocCheck` that need to be green for acceptance to Bioconductor.

There is also an automated creation and deployment of documentation based on `pkgdown`, which likely requires activation of GitHub pages in the settings to work.

At the moment, the tests still fail (for example due to non-runnable examples). I hope it's still usefull to prepare for the submission.